### PR TITLE
Add client.id property

### DIFF
--- a/src/main/java/io/kcache/KafkaCache.java
+++ b/src/main/java/io/kcache/KafkaCache.java
@@ -74,6 +74,7 @@ public class KafkaCache<K, V> implements Cache<K, V> {
     private String topic;
     private int desiredReplicationFactor;
     private String groupId;
+    private String clientId;
     private CacheUpdateHandler<K, V> cacheUpdateHandler;
     private Serde<K> keySerde;
     private Serde<V> valueSerde;
@@ -117,6 +118,10 @@ public class KafkaCache<K, V> implements Cache<K, V> {
         this.topic = config.getString(KafkaCacheConfig.KAFKACACHE_TOPIC_CONFIG);
         this.desiredReplicationFactor = config.getInt(KafkaCacheConfig.KAFKACACHE_TOPIC_REPLICATION_FACTOR_CONFIG);
         this.groupId = config.getString(KafkaCacheConfig.KAFKACACHE_GROUP_ID_CONFIG);
+        this.clientId = config.getString(KafkaCacheConfig.KAFKACACHE_CLIENT_ID_CONFIG);
+        if (this.clientId == null) {
+        	this.clientId = "kafka-cache-reader-" + this.topic;
+        }
         this.initTimeout = config.getInt(KafkaCacheConfig.KAFKACACHE_INIT_TIMEOUT_CONFIG);
         this.timeout = config.getInt(KafkaCacheConfig.KAFKACACHE_TIMEOUT_CONFIG);
         this.cacheUpdateHandler = cacheUpdateHandler != null ? cacheUpdateHandler : (key, value) -> {
@@ -158,7 +163,7 @@ public class KafkaCache<K, V> implements Cache<K, V> {
         Properties consumerProps = new Properties();
         addKafkaCacheConfigsToClientProperties(consumerProps);
         consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, this.groupId);
-        consumerProps.put(ConsumerConfig.CLIENT_ID_CONFIG, "kafka-cache-reader-" + this.topic);
+        consumerProps.put(ConsumerConfig.CLIENT_ID_CONFIG, clientId);
 
         consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapBrokers);
         consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");

--- a/src/main/java/io/kcache/KafkaCacheConfig.java
+++ b/src/main/java/io/kcache/KafkaCacheConfig.java
@@ -37,6 +37,10 @@ public class KafkaCacheConfig extends AbstractConfig {
     public static final String KAFKACACHE_GROUP_ID_CONFIG = "kafkacache.group.id";
     public static final String DEFAULT_KAFKACACHE_GROUP_ID = "kafkacache";
     /**
+     * <code>kafkacache.client.id</code>
+     */
+    public static final String KAFKACACHE_CLIENT_ID_CONFIG = "kafkacache.client.id";
+    /**
      * <code>kafkacache.topic</code>
      */
     public static final String KAFKACACHE_TOPIC_CONFIG = "kafkacache.topic";
@@ -59,6 +63,8 @@ public class KafkaCacheConfig extends AbstractConfig {
         "A list of Kafka brokers to connect to. For example, `PLAINTEXT://hostname:9092,SSL://hostname2:9092`.";
     protected static final String KAFKACACHE_GROUP_ID_DOC =
         "Use this setting to override the group.id for the Kafka cache consumer.";
+    protected static final String KAFKACACHE_CLIENT_ID_DOC =
+            "Use this setting to override the client.id for the Kafka cache consumer.";
     protected static final String KAFKACACHE_TOPIC_DOC =
         "The durable single partition topic that acts as the durable log for the data.";
     protected static final String KAFKACACHE_TOPIC_REPLICATION_FACTOR_DOC =
@@ -97,6 +103,9 @@ public class KafkaCacheConfig extends AbstractConfig {
             )
             .define(KAFKACACHE_GROUP_ID_CONFIG, ConfigDef.Type.STRING, DEFAULT_KAFKACACHE_GROUP_ID,
                 ConfigDef.Importance.LOW, KAFKACACHE_GROUP_ID_DOC
+            )
+            .define(KAFKACACHE_CLIENT_ID_CONFIG, ConfigDef.Type.STRING, null,
+                    ConfigDef.Importance.LOW, KAFKACACHE_CLIENT_ID_DOC
             );
     }
 


### PR DESCRIPTION
Give the abity to specify the client.id for the consumer. This may be useful if 2 cache instances are started from 2 threads in that case an InstanceAlreadyExistsException is raised.

Stack:
```
javax.management.InstanceAlreadyExistsException: kafka.producer:type=app-info,id=producer-1
	at com.sun.jmx.mbeanserver.Repository.addMBean(Repository.java:437)
	at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerWithRepository(DefaultMBeanServerInterceptor.java:1898)
	at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerDynamicMBean(DefaultMBeanServerInterceptor.java:966)
	at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerObject(DefaultMBeanServerInterceptor.java:900)
	at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerMBean(DefaultMBeanServerInterceptor.java:324)
	at com.sun.jmx.mbeanserver.JmxMBeanServer.registerMBean(JmxMBeanServer.java:522)
	at org.apache.kafka.common.utils.AppInfoParser.registerAppInfo(AppInfoParser.java:62)
	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:451)
	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:304)
```
