### PR TITLE
Enable custom partitioning

### DIFF
--- a/kcache/src/test/java/io/kcache/CacheUtils.java
+++ b/kcache/src/test/java/io/kcache/CacheUtils.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.serialization.Serdes;
 
 import java.util.Map;
 import java.util.Properties;
+import java.util.function.BiFunction;
 
 public class CacheUtils {
 
@@ -44,6 +45,22 @@ public class CacheUtils {
         kafkaCache.init();
         return kafkaCache;
     }
+
+    public static Cache<String, String> createAndInitKafkaCacheInstanceWithCustomPartitioner(
+        Properties props, BiFunction<String, String, Integer> customPartitioner)
+        throws CacheInitializationException {
+        KafkaCacheConfig config = new KafkaCacheConfig(props);
+        Cache<String, String> kafkaCache = Caches.concurrentCache(
+            new KafkaCache<>(config,
+                Serdes.String(),
+                Serdes.String(),
+                new StringUpdateHandler(),
+                null,
+                customPartitioner));
+        kafkaCache.init();
+        return kafkaCache;
+    }
+
     /**
      * Get a new instance of an SASL KafkaCache and initialize it.
      */


### PR DESCRIPTION
Sometimes you don't want the cache/kafka key to be your partitioning key. 

For example, say you're tracking users by organization, and you have consumers responsible for a subset of orgs. You can key by user id to guarantee uniqueness, but partition by org id so that the downstream caches are always responsible for a single partition.

This adds the option to include a `BiFunction<K, V, Integer>` that determines the appropriate partition for the given data, enabling custom partitioning.